### PR TITLE
Enhance learning path for frontend to AI engineer transition

### DIFF
--- a/learning-paths/from-frontend-engineer.md
+++ b/learning-paths/from-frontend-engineer.md
@@ -2,7 +2,6 @@
 
 Frontend engineers follow a similar path as other engineers. AI engineers focus more on the backend, so you would need to build up your backend skills first. But you have a unique advantage: you can close the entire full stack end-to-end.
 
-
 ## What You Already Have
 
 - TypeScript/JavaScript
@@ -12,43 +11,95 @@ Frontend engineers follow a similar path as other engineers. AI engineers focus 
 - UI/UX sensibility - valuable for AI products
 - Product sense
 
-
 ## What You Need to Learn
 
-- Backend development - start with TypeScript (you don't need Python initially). FastAPI if you go the Python route
-- Databases - PostgreSQL, Redis, vector databases
-- Docker, CI/CD
-- Cloud platforms - AWS, Azure, GCP
-- LLM APIs - OpenAI, Anthropic. Structured outputs, function calling
-- Prompt engineering
-- RAG patterns - vector search, embeddings, retrieval
-- Agent patterns - LLMs with tools, orchestration
-- Evaluation - test sets, LLM-as-judge, quality metrics
-- Basic ML concepts - embeddings, fine-tuning concepts
+### Backend Development
 
+**Two paths to choose from:**
+
+**Path One: TypeScript (Recommended)**
+- Use Node.js/Express or Next.js API Routes
+- Pros: No new language to learn, gradual transition
+- Fit: Those who prefer full stack consistency and JavaScript ecosystem
+
+**Path Two: Python (Strongly Recommended)**
+- FastAPI: Modern high-performance Python web framework, excellent API design
+- Flask/Django: Traditional options, rich ecosystem
+- Pros: Python dominates the AI space, many AI libraries are Python-first
+- Fit: Those who want to dive deep into AI/ML and align with the mainstream AI tech stack
+
+> **Tip**: If you have time, consider doing both. TypeScript as your backup, Python for depth. Python's advantage in the AI ecosystem cannot be ignored.
+
+### Databases
+
+- PostgreSQL (relational)
+- Redis (caching)
+- Vector databases: Chroma, Milvus, Pinecone, Qdrant (essential for RAG)
+
+### Deployment & DevOps
+
+- Docker
+- CI/CD
+- Cloud platforms: AWS, Azure, GCP
+
+### AI/ML Core Skills
+
+- LLM APIs: OpenAI, Anthropic
+  - Structured outputs
+  - Function calling
+- Prompt engineering
+- RAG patterns
+  - Vector search
+  - Embeddings
+  - Retrieval
+- Agent patterns
+  - LLMs with tools
+  - Orchestration
+- Evaluation
+  - Test sets
+  - LLM-as-judge
+  - Quality metrics
+- Basic ML concepts
+  - Embeddings
+  - Fine-tuning concepts
+
+### Python Advanced (if choosing Python path)
+
+- Async programming: asyncio
+- Data processing: Pandas, NumPy
+- AI libraries: LangChain, LlamaIndex, AutoGen
 
 ## Why This Transition Works
 
-Instead of Python, it is perfectly fine to use TypeScript. There are plenty of AI engineering jobs that require TypeScript and plenty of projects built in TypeScript.
+Not learning Python is fine - using TypeScript is completely viable. There are plenty of AI engineering jobs that require TypeScript and plenty of projects built in TypeScript.
 
 From frontend, you can easily transition to full stack. Do backend in TypeScript. Once you have backend and full stack experience, add AI on top. Your advantage over other engineers: they cannot do what you can - you can close the entire full stack end-to-end, from writing the backend to integrating it into the product.
 
-
 ## Suggested Path
 
-1. Learn backend - do it in TypeScript. Build APIs, learn databases
+### If choosing TypeScript route
+
+1. Learn backend - do it in TypeScript + Node.js. Build APIs, learn databases
 2. Learn Docker and basic deployment
 3. Pick up an AI assistant (Cursor, Claude Code) - use it to accelerate your backend learning
 4. Start with LLM APIs - call OpenAI/Anthropic from your backend
-5. Build a full-stack AI app - chatbot, RAG system, or extraction tool. You build both the UI and the backend
+5. Build a full-stack AI app - chatbot, RAG system, or extraction tool
 6. Learn evaluation - test sets, quality metrics
 7. Learn agents - tool use, orchestration
 
+### If choosing Python route
+
+1. Learn Python basics + FastAPI
+2. Learn SQL and database design
+3. Learn Docker
+4. Master LangChain/LlamaIndex
+5. Build RAG systems
+6. Learn Agent frameworks (AutoGen, Claude Agent SDK)
+7. Deploy to production
 
 ## Timeline
 
 Longer than backend engineers because you need the backend foundation first. But once backend clicks, adding AI is the same path as everyone else.
-
 
 ## Your Advantage
 


### PR DESCRIPTION
Expanded the learning path from frontend engineer to AI engineer by detailing backend development options, database skills, deployment practices, and AI/ML core skills. Added suggested paths for both TypeScript and Python routes, emphasizing the unique advantages of full-stack capabilities.