### PR TITLE
Add AI Engineering course to Courses

### DIFF
--- a/awesome.md
+++ b/awesome.md
@@ -191,6 +191,7 @@ This is the list of resources I used while researching content for the [AI Engin
 - [Educative: Grokking Generative AI System Design](https://www.educative.io/courses/generative-ai-system-design) - SCALED framework, mock interviews
 - [Lenny's Newsletter: Building Eval Systems](https://www.lennysnewsletter.com/p/building-eval-systems-that-improve-cec) - Shreya Shankar
 - [Lenny's Newsletter: Why AI Evals Are the Hottest New Skill](https://www.lennysnewsletter.com/p/why-ai-evals-are-the-hottest-new-skill)
+- [AI Engineering](https://www.systemdesign.academy/ai-engineering) - Roni Das, interactive lessons covering RAG, agents, fine-tuning, evaluation, serving and LLMOps
 
 
 


### PR DESCRIPTION
One entry added to the bottom of the Courses section in `awesome.md`, following the existing `[name](link) - author, description` format.

It is an interactive course rather than video: lessons are slide based, diagrams reveal step by step, and code examples run in the browser. Coverage is RAG, agents, fine-tuning, evaluation, serving and LLMOps, so it sits closest to the LLM Zoomcamp and Educative entries already listed.

**Disclosure:** I built it, and part of it is paid with a free foundation tier. Saying so up front rather than letting you find out. If the list is meant for free resources only, no hard feelings and feel free to close this.

One file, one line.